### PR TITLE
Treat string options as case sensitive

### DIFF
--- a/src/main/java/de/uniluebeck/itm/ncoap/message/options/StringOption.java
+++ b/src/main/java/de/uniluebeck/itm/ncoap/message/options/StringOption.java
@@ -68,7 +68,7 @@ public class StringOption extends Option{
             value =  value.toLowerCase(Locale.ENGLISH);
         }
         setValue(optionName,
-                 convertToByteArrayWithoutPercentEncoding(optionName, value.toLowerCase(Locale.ENGLISH)));
+                 convertToByteArrayWithoutPercentEncoding(optionName, value));
     }
 
     //Sets the options value after checking option specific constraints


### PR DESCRIPTION
Without this modification every String option is lowercased.
At least for path fragments, this behaviour is clearly wrong.
e.g.:
`coap://locahost/states/CHryD`
would be interpreted as
`coap://locahost/states/chryd`

[See section 6.4 of the coap-08 draft](http://tools.ietf.org/html/draft-ietf-core-coap-08#section-6.4)
