### PR TITLE
Do not register a service twice.

### DIFF
--- a/ncoap-core/src/main/java/de/uniluebeck/itm/ncoap/communication/dispatching/server/WebserviceManager.java
+++ b/ncoap-core/src/main/java/de/uniluebeck/itm/ncoap/communication/dispatching/server/WebserviceManager.java
@@ -396,6 +396,12 @@ public class WebserviceManager extends SimpleChannelUpstreamHandler {
      */
     public final void registerService(final Webservice webservice) {
         webservice.setWebserviceManager(this);
+
+        if(registeredServices.containsKey(webservice.getUriPath())) {
+            log.warn("Service {} is already registered!", webservice.getUriPath());
+        	return;
+        }
+
         registeredServices.put(webservice.getUriPath(), webservice);
         log.info("Registered new service at " + webservice.getUriPath());
 


### PR DESCRIPTION
It was possible to register the same resoruce twice. This is fixed and a WARN log is written.