### PR TITLE
.well-known/core not registered within CoapEndpoint

### DIFF
--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/endpoint/CoapEndpoint.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/endpoint/CoapEndpoint.java
@@ -140,6 +140,9 @@ public class CoapEndpoint extends AbstractCoapApplication {
         // retrieve the request dispatcher (server component)
         this.requestDispatcher = getChannel().getPipeline().get(RequestDispatcher.class);
 
+        // register .well-known/core
+        this.requestDispatcher.registerWellKnownCoreResource();
+
         // retrieve the response dispatcher (client component)
         this.responseDispatcher = getChannel().getPipeline().get(ResponseDispatcher.class);
     }


### PR DESCRIPTION
Compared to the `CoapServer`, the `CoapEndpoint`did not register `.well.known/core`.