### PR TITLE
Netty 4.0

### DIFF
--- a/ncoap-core/pom.xml
+++ b/ncoap-core/pom.xml
@@ -26,6 +26,10 @@
         </repository>
     </repositories>
 
+    <properties>
+        <netty.version>4.0.37.Final</netty.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -34,8 +38,23 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.9.0.Final</version>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/AbstractCoapApplication.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/AbstractCoapApplication.java
@@ -24,22 +24,19 @@
  */
 package de.uzl.itm.ncoap.application;
 
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
-import org.jboss.netty.bootstrap.ConnectionlessBootstrap;
-import org.jboss.netty.channel.ChannelFactory;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.FixedReceiveBufferSizePredictor;
-import org.jboss.netty.channel.socket.DatagramChannel;
-import org.jboss.netty.channel.socket.nio.NioDatagramChannelFactory;
-import org.jboss.netty.channel.socket.oio.OioDatagramChannelFactory;
-import org.jboss.netty.util.ThreadNameDeterminer;
-import org.jboss.netty.util.ThreadRenamingRunnable;
-
 import java.net.InetSocketAddress;
-import java.util.concurrent.*;
+
+import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
  * The abstract base class for all kinds of CoAP applications, i.e. clients, servers, and endpoints (combining client
@@ -59,7 +56,7 @@ public abstract class AbstractCoapApplication {
      */
     public static final int NOT_BOUND = -1;
 
-    private ScheduledThreadPoolExecutor executor;
+    private EventLoopGroup executor;
     private DatagramChannel channel;
     private String applicationName;
 
@@ -73,20 +70,9 @@ public abstract class AbstractCoapApplication {
 
         this.applicationName = applicationName;
 
-        ThreadFactory threadFactory =
-                new ThreadFactoryBuilder().setNameFormat(applicationName + " I/O Worker #%d").build();
-
-        ThreadRenamingRunnable.setThreadNameDeterminer(new ThreadNameDeterminer() {
-            @Override
-            public String determineThreadName(String currentThreadName, String proposedThreadName) throws Exception {
-                return null;
-            }
-        });
-
         // determine number of I/O threads and create thread pool executor of that size
         int ioThreads = Math.max(Runtime.getRuntime().availableProcessors() * 2, 4);
-        this.executor = new ScheduledThreadPoolExecutor(ioThreads, threadFactory);
-//        this.executor = new SynchronizedExecutor(ioThreads, threadFactory);
+        this.executor = new NioEventLoopGroup(ioThreads, new DefaultThreadFactory(applicationName + "I/O Worker"));
     }
 
     /**
@@ -97,40 +83,36 @@ public abstract class AbstractCoapApplication {
      * @param localSocket the socket address to be used for inbound and outbound messages
      */
     protected void startApplication(CoapChannelPipelineFactory pipelineFactory, InetSocketAddress localSocket) {
-        //ChannelFactory channelFactory = new NioDatagramChannelFactory(executor, executor.getCorePoolSize() / 2 );
-        ChannelFactory channelFactory = new NioDatagramChannelFactory(executor, 1 );
-
-        //System.out.println("Threads: " + (executor.getCorePoolSize() - 1));
-        //Create and configure bootstrap
-        ConnectionlessBootstrap bootstrap = new ConnectionlessBootstrap(channelFactory);
-        bootstrap.setPipelineFactory(pipelineFactory);
-        bootstrap.setOption("receiveBufferSizePredictor",
-                new FixedReceiveBufferSizePredictor(RECEIVE_BUFFER_SIZE));
+        Bootstrap bootstrap = new Bootstrap()
+                .channel(NioDatagramChannel.class)
+                .group(executor)
+                .option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(RECEIVE_BUFFER_SIZE))
+                .handler(pipelineFactory);
 
         //Create datagram channel
-        this.channel = (DatagramChannel) bootstrap.bind(localSocket);
+        this.channel = (DatagramChannel) bootstrap.bind(localSocket).awaitUninterruptibly().channel();
 
         // set the channel handler contexts
         for (ChannelHandler handler : pipelineFactory.getChannelHandlers()) {
             if (handler instanceof AbstractCoapChannelHandler) {
-                ChannelHandlerContext context = this.channel.getPipeline().getContext(handler.getClass());
+                ChannelHandlerContext context = this.channel.pipeline().context(handler.getClass());
                 ((AbstractCoapChannelHandler) handler).setContext(context);
             }
         }
     }
 
     /**
-     * Returns the local port number the {@link org.jboss.netty.channel.socket.DatagramChannel} of this
+     * Returns the local port number the {@link DatagramChannel} of this
      * {@link de.uzl.itm.ncoap.application.client.CoapClient} is bound to or
      * {@link #NOT_BOUND} if the application has not yet been started.
      *
-     * @return the local port number the {@link org.jboss.netty.channel.socket.DatagramChannel} of this
+     * @return the local port number the {@link DatagramChannel} of this
      * {@link de.uzl.itm.ncoap.application.client.CoapClient} is bound to or
      * {@link #NOT_BOUND} if the application has not yet been started.
      */
     public int getPort() {
         try {
-            return this.channel.getLocalAddress().getPort();
+            return this.channel.localAddress().getPort();
         } catch(Exception ex) {
             return NOT_BOUND;
         }
@@ -147,7 +129,7 @@ public abstract class AbstractCoapApplication {
      * {@link de.uzl.itm.ncoap.application.AbstractCoapApplication} to handle tasks, e.g. write and
      * receive messages.
      */
-    public ScheduledExecutorService getExecutor() {
+    public EventLoopGroup getExecutor() {
         return this.executor;
     }
 

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/CoapChannelPipelineFactory.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/CoapChannelPipelineFactory.java
@@ -24,35 +24,34 @@
  */
 package de.uzl.itm.ncoap.application;
 
-import de.uzl.itm.ncoap.communication.codec.CoapMessageDecoder;
-import de.uzl.itm.ncoap.communication.codec.CoapMessageEncoder;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.Channels;
-import org.jboss.netty.handler.execution.ExecutionHandler;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.concurrent.ScheduledExecutorService;
+import de.uzl.itm.ncoap.communication.codec.CoapMessageDecoder;
+import de.uzl.itm.ncoap.communication.codec.CoapMessageEncoder;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
 
 /**
  * Abstract base class for pipeline factories for clients, servers and peers.
  *
  * @author Oliver Kleine
  */
-public abstract class CoapChannelPipelineFactory implements ChannelPipelineFactory {
+public abstract class CoapChannelPipelineFactory extends ChannelInitializer<Channel> {
 
     private static Logger LOG = LoggerFactory.getLogger(CoapChannelPipelineFactory.class.getName());
 
     private Set<ChannelHandler> channelHandlers;
 
 
-    protected CoapChannelPipelineFactory(ScheduledExecutorService executor) {
+    protected CoapChannelPipelineFactory() {
         this.channelHandlers = new LinkedHashSet<>();
 
-        addChannelHandler(new ExecutionHandler(executor));
         addChannelHandler(new CoapMessageEncoder());
         addChannelHandler(new CoapMessageDecoder());
      }
@@ -67,16 +66,15 @@ public abstract class CoapChannelPipelineFactory implements ChannelPipelineFacto
     }
 
     @Override
-    public ChannelPipeline getPipeline() throws Exception {
-        ChannelPipeline pipeline = Channels.pipeline();
+    protected void initChannel(Channel channel) throws Exception
+    {
+        ChannelPipeline pipeline = channel.pipeline();
 
         for(ChannelHandler handler : this.channelHandlers) {
             String handlerName = handler.getClass().getSimpleName();
             pipeline.addLast(handler.getClass().getSimpleName(), handler);
             LOG.debug("Added Handler to Pipeline: {}.", handlerName);
         }
-
-        return pipeline;
     }
 
 //    /**

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/ClientCallback.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/ClientCallback.java
@@ -24,12 +24,10 @@
  */
 package de.uzl.itm.ncoap.application.client;
 
+import java.net.InetSocketAddress;
+
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.message.CoapResponse;
-import org.jboss.netty.buffer.ChannelBuffer;
-import de.uzl.itm.ncoap.message.options.Option;
-
-import java.net.InetSocketAddress;
 
 
 /**

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/ClientChannelPipelineFactory.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/ClientChannelPipelineFactory.java
@@ -24,6 +24,8 @@
  */
 package de.uzl.itm.ncoap.application.client;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import de.uzl.itm.ncoap.application.CoapChannelPipelineFactory;
 import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock1Handler;
 import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock2Handler;
@@ -34,10 +36,8 @@ import de.uzl.itm.ncoap.communication.observing.ClientObservationHandler;
 import de.uzl.itm.ncoap.communication.reliability.inbound.ClientInboundReliabilityHandler;
 import de.uzl.itm.ncoap.communication.reliability.outbound.ClientOutboundReliabilityHandler;
 import de.uzl.itm.ncoap.communication.reliability.outbound.MessageIDFactory;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.socket.DatagramChannel;
-
-import java.util.concurrent.ScheduledExecutorService;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.DatagramChannel;
 
 
 /**
@@ -56,7 +56,7 @@ public class ClientChannelPipelineFactory extends CoapChannelPipelineFactory {
      */
     public ClientChannelPipelineFactory(ScheduledExecutorService executor) {
 
-        super(executor);
+        super();
         addChannelHandler(new ClientIdentificationHandler(executor));
         addChannelHandler(new ClientOutboundReliabilityHandler(executor, new MessageIDFactory(executor)));
         addChannelHandler(new ClientInboundReliabilityHandler(executor));

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/CoapClient.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/client/CoapClient.java
@@ -24,18 +24,19 @@
  */
 package de.uzl.itm.ncoap.application.client;
 
+import java.net.InetSocketAddress;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.uzl.itm.ncoap.application.AbstractCoapApplication;
-import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.communication.dispatching.client.ResponseDispatcher;
 import de.uzl.itm.ncoap.message.CoapMessage;
 import de.uzl.itm.ncoap.message.CoapRequest;
 import de.uzl.itm.ncoap.message.CoapResponse;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.InetSocketAddress;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.socket.DatagramChannel;
 
 /**
  * An instance of {@link CoapClient} is the entry point to send {@link CoapMessage}s to a (remote)
@@ -98,7 +99,7 @@ public class CoapClient extends AbstractCoapApplication {
         ClientChannelPipelineFactory factory = new ClientChannelPipelineFactory(this.getExecutor());
         startApplication(factory, clientSocket);
 
-        this.responseDispatcher = getChannel().getPipeline().get(ResponseDispatcher.class);
+        this.responseDispatcher = getChannel().pipeline().get(ResponseDispatcher.class);
     }
 
 
@@ -150,8 +151,8 @@ public class CoapClient extends AbstractCoapApplication {
 
     /**
      * Shuts this {@link CoapClient} down by closing its
-     * {@link org.jboss.netty.channel.socket.DatagramChannel} which includes to unbind
-     * this {@link org.jboss.netty.channel.socket.DatagramChannel} from the listening port and by this means free the
+     * {@link DatagramChannel} which includes to unbind
+     * this {@link DatagramChannel} from the listening port and by this means free the
      * port.
      */
     public final void shutdown() {
@@ -161,10 +162,10 @@ public class CoapClient extends AbstractCoapApplication {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 LOG.warn("Channel closed ({}).", CoapClient.this.getApplicationName());
-                getChannel().getFactory().releaseExternalResources();
                 LOG.warn("External resources released ({}).", CoapClient.this.getApplicationName());
                 LOG.warn("Shutdown of " + getApplicationName() + " completed.");
             }
         });
+        getExecutor().shutdownGracefully();
     }
 }

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/endpoint/CoapEndpointChannelPipelineFactory.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/endpoint/CoapEndpointChannelPipelineFactory.java
@@ -24,8 +24,9 @@
  */
 package de.uzl.itm.ncoap.application.endpoint;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import de.uzl.itm.ncoap.application.CoapChannelPipelineFactory;
-//import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock2Handler;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock1Handler;
 import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock2Handler;
@@ -45,12 +46,13 @@ import de.uzl.itm.ncoap.communication.reliability.inbound.ServerInboundReliabili
 import de.uzl.itm.ncoap.communication.reliability.outbound.ClientOutboundReliabilityHandler;
 import de.uzl.itm.ncoap.communication.reliability.outbound.MessageIDFactory;
 import de.uzl.itm.ncoap.communication.reliability.outbound.ServerOutboundReliabilityHandler;
+import io.netty.channel.ChannelPipeline;
 
-import java.util.concurrent.ScheduledExecutorService;
+//import de.uzl.itm.ncoap.communication.blockwise.client.ClientBlock2Handler;
 
 /**
  * The {@link de.uzl.itm.ncoap.application.CoapChannelPipelineFactory} to create the proper
- * {@link org.jboss.netty.channel.ChannelPipeline} for {@link CoapEndpoint}s.
+ * {@link ChannelPipeline} for {@link CoapEndpoint}s.
  *
  * @author Oliver Kleine
  */
@@ -70,7 +72,7 @@ public class CoapEndpointChannelPipelineFactory extends CoapChannelPipelineFacto
     public CoapEndpointChannelPipelineFactory(ScheduledExecutorService executor, TokenFactory tokenFactory,
                              NotFoundHandler notFoundHandler, BlockSize maxBlock1Size, BlockSize maxBlock2Size) {
 
-        super(executor);
+        super();
         MessageIDFactory factory = new MessageIDFactory(executor);
 
         // identification

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/server/CoapServerChannelPipelineFactory.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/application/server/CoapServerChannelPipelineFactory.java
@@ -24,6 +24,8 @@
  */
 package de.uzl.itm.ncoap.application.server;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import de.uzl.itm.ncoap.application.CoapChannelPipelineFactory;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.communication.blockwise.server.ServerBlock1Handler;
@@ -35,10 +37,8 @@ import de.uzl.itm.ncoap.communication.observing.ServerObservationHandler;
 import de.uzl.itm.ncoap.communication.reliability.inbound.ServerInboundReliabilityHandler;
 import de.uzl.itm.ncoap.communication.reliability.outbound.MessageIDFactory;
 import de.uzl.itm.ncoap.communication.reliability.outbound.ServerOutboundReliabilityHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.socket.DatagramChannel;
-
-import java.util.concurrent.ScheduledExecutorService;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.DatagramChannel;
 
 /**
 * Factory to provide the {@link ChannelPipeline} for newly created {@link DatagramChannel}s.
@@ -58,7 +58,7 @@ public class CoapServerChannelPipelineFactory extends CoapChannelPipelineFactory
     public CoapServerChannelPipelineFactory(ScheduledExecutorService executor, NotFoundHandler notFoundHandler,
                                             BlockSize maxBlock1Size, BlockSize maxBlock2Size) {
 
-        super(executor);
+        super();
         addChannelHandler(new ServerIdentificationHandler(executor));
         addChannelHandler(new ServerOutboundReliabilityHandler(executor, new MessageIDFactory(executor)));
         addChannelHandler(new ServerInboundReliabilityHandler(executor));

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/AbstractCoapChannelHandler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/AbstractCoapChannelHandler.java
@@ -229,7 +229,7 @@ public abstract class AbstractCoapChannelHandler extends ChannelDuplexHandler{
     protected void sendEmptyACK(int messageID, final InetSocketAddress remoteSocket) {
         final CoapMessage emptyACK = CoapMessage.createEmptyAcknowledgement(messageID);
         // Need to encode CoapMessage to UDP with remote socket here.
-        ChannelFuture future = context.writeAndFlush(emptyACK);
+        ChannelFuture future = context.writeAndFlush(new CoapMessageEnvelope(emptyACK, remoteSocket));
         if (LOG.isDebugEnabled()) {
             future.addListener(new ChannelFutureListener() {
                 @Override
@@ -249,7 +249,7 @@ public abstract class AbstractCoapChannelHandler extends ChannelDuplexHandler{
      */
     protected void sendReset(int messageID, final InetSocketAddress remoteSocket) {
         final CoapMessage resetMessage = CoapMessage.createEmptyReset(messageID);
-        ChannelFuture future = context.writeAndFlush(resetMessage);
+        ChannelFuture future = context.writeAndFlush(new CoapMessageEnvelope(resetMessage, remoteSocket));
         if (LOG.isDebugEnabled()) {
             future.addListener(new ChannelFutureListener() {
                 @Override

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/client/ClientBlock1Handler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/client/ClientBlock1Handler.java
@@ -24,12 +24,19 @@
  */
 package de.uzl.itm.ncoap.communication.blockwise.client;
 
+import java.net.InetSocketAddress;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.HashBasedTable;
 import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.events.client.RemoteServerSocketChangedEvent;
 import de.uzl.itm.ncoap.communication.events.client.ContinueResponseReceivedEvent;
+import de.uzl.itm.ncoap.communication.events.client.RemoteServerSocketChangedEvent;
 import de.uzl.itm.ncoap.communication.events.client.TokenReleasedEvent;
 import de.uzl.itm.ncoap.message.CoapMessage;
 import de.uzl.itm.ncoap.message.CoapRequest;
@@ -37,15 +44,9 @@ import de.uzl.itm.ncoap.message.CoapResponse;
 import de.uzl.itm.ncoap.message.MessageCode;
 import de.uzl.itm.ncoap.message.options.Option;
 import de.uzl.itm.ncoap.message.options.UintOptionValue;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.InetSocketAddress;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 
 /**
  * The {@link ClientBlock1Handler} handles the {@link Option#BLOCK_1} for
@@ -201,7 +202,7 @@ public class ClientBlock1Handler extends AbstractCoapChannelHandler implements T
         private long block2Szx;
         private InetSocketAddress remoteSocket;
         private CoapRequest coapRequest;
-        private ChannelBuffer completePayload;
+        private ByteBuf completePayload;
 
 
         private ClientBlock1Helper(CoapRequest coapRequest, InetSocketAddress remoteSocket) {

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/server/ServerBlock2Handler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/server/ServerBlock2Handler.java
@@ -24,6 +24,13 @@
  */
 package de.uzl.itm.ncoap.communication.blockwise.server;
 
+import java.net.InetSocketAddress;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.HashBasedTable;
 import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
@@ -35,17 +42,11 @@ import de.uzl.itm.ncoap.message.MessageCode;
 import de.uzl.itm.ncoap.message.options.ContentFormat;
 import de.uzl.itm.ncoap.message.options.Option;
 import de.uzl.itm.ncoap.message.options.UintOptionValue;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 
-import static de.uzl.itm.ncoap.message.MessageCode.*;
-
-import java.net.InetSocketAddress;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import static de.uzl.itm.ncoap.message.MessageCode.PRECONDITION_FAILED_412;
 
 /**
  * <p>The {@link ServerBlock2Handler} handles the {@link Option#BLOCK_2} for
@@ -222,7 +223,7 @@ public class ServerBlock2Handler extends AbstractCoapChannelHandler {
 
         private long block2Szx;
         private CoapResponse coapResponse;
-        private ChannelBuffer completeRepresentation;
+        private ByteBuf completeRepresentation;
         private InetSocketAddress remoteSocket;
 
         public ServerBlock2Helper(CoapResponse coapResponse, InetSocketAddress remoteSocket) {

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/server/ServerBlock2Handler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/server/ServerBlock2Handler.java
@@ -259,11 +259,14 @@ public class ServerBlock2Handler extends AbstractCoapChannelHandler {
             this.coapResponse.setBlock2(block2Num, block2more, block2Szx);
 
             //set the payload block
+            ByteBuf slice;
             if (block2more) {
-                this.coapResponse.setContent(this.completeRepresentation.slice(startIndex, block2Size));
+                slice = this.completeRepresentation.slice(startIndex, block2Size);
             } else {
-                this.coapResponse.setContent(this.completeRepresentation.slice(startIndex, remaining));
+                slice = this.completeRepresentation.slice(startIndex, remaining);
             }
+            this.completeRepresentation.retain();
+            this.coapResponse.setContent(slice);
 
             ChannelFuture future = sendCoapMessage(coapResponse, remoteSocket);
             future.addListener(new ChannelFutureListener() {

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageDecoder.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageDecoder.java
@@ -43,7 +43,7 @@ import de.uzl.itm.ncoap.message.options.StringOptionValue;
 import de.uzl.itm.ncoap.message.options.UintOptionValue;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 
 import static de.uzl.itm.ncoap.message.MessageCode.BAD_OPTION_402;
@@ -82,20 +82,14 @@ import static de.uzl.itm.ncoap.message.MessageType.RST;
  *
  * @author Oliver Kleine
  */
-public class CoapMessageDecoder extends ChannelInboundHandlerAdapter
+public class CoapMessageDecoder extends SimpleChannelInboundHandler<DatagramPacket>
 {
 
     private Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
 
-        if (!(evt instanceof DatagramPacket)) {
-            ctx.fireChannelRead(evt);
-            return;
-        }
-
-        DatagramPacket packet = (DatagramPacket) evt;
         InetSocketAddress remoteSocket = packet.sender();
         CoapMessage coapMessage = decode(remoteSocket, packet.content());
 

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageEncoder.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageEncoder.java
@@ -166,7 +166,7 @@ public class CoapMessageEncoder extends ChannelOutboundHandlerAdapter {
             encodedMessage.writeByte(255);
 
             // add payload
-            encodedMessage = Unpooled.wrappedBuffer(encodedMessage, coapMessage.getContent());
+            encodedMessage = Unpooled.wrappedBuffer(encodedMessage, coapMessage.getContent().retain());
             LOG.debug("Encoded length of message (after CONTENT): {}", encodedMessage.readableBytes());
         }
 

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/observing/ServerObservationHandler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/observing/ServerObservationHandler.java
@@ -24,25 +24,6 @@
  */
 package de.uzl.itm.ncoap.communication.observing;
 
-import com.google.common.collect.HashBasedTable;
-import de.uzl.itm.ncoap.application.server.CoapServer;
-import de.uzl.itm.ncoap.application.server.resource.ObservableWebresource;
-import de.uzl.itm.ncoap.application.server.resource.WrappedResourceStatus;
-import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
-import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
-import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.events.TransmissionTimeoutEvent;
-import de.uzl.itm.ncoap.communication.events.server.RemoteClientSocketChangedEvent;
-import de.uzl.itm.ncoap.communication.events.server.ObserverAcceptedEvent;
-import de.uzl.itm.ncoap.communication.events.ResetReceivedEvent;
-import de.uzl.itm.ncoap.message.*;
-import de.uzl.itm.ncoap.message.options.ContentFormat;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.Channels;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +31,29 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashBasedTable;
+import de.uzl.itm.ncoap.application.server.CoapServer;
+import de.uzl.itm.ncoap.application.server.resource.ObservableWebresource;
+import de.uzl.itm.ncoap.application.server.resource.WrappedResourceStatus;
+import de.uzl.itm.ncoap.communication.AbstractCoapChannelHandler;
+import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
+import de.uzl.itm.ncoap.communication.dispatching.Token;
+import de.uzl.itm.ncoap.communication.events.ResetReceivedEvent;
+import de.uzl.itm.ncoap.communication.events.TransmissionTimeoutEvent;
+import de.uzl.itm.ncoap.communication.events.server.ObserverAcceptedEvent;
+import de.uzl.itm.ncoap.communication.events.server.RemoteClientSocketChangedEvent;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.CoapResponse;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
+import de.uzl.itm.ncoap.message.options.ContentFormat;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 
 /**
  * The {@link ServerObservationHandler} is responsible to maintain the list of registered clients observing any
@@ -342,14 +346,12 @@ public class ServerObservationHandler extends AbstractCoapChannelHandler impleme
             coapResponse.setPreferredBlock2Size(block2Size);
 
             ChannelFuture future = sendCoapMessage(coapResponse, this.remoteSocket);
-//            ChannelFuture future = Channels.future(getContext().getChannel());
-//            Channels.write(getContext(), future, coapResponse, remoteSocket);
 
             future.addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     if (!future.isSuccess()) {
-                        LOG.error("Shutdown Notification Failure!", future.getCause());
+                        LOG.error("Shutdown Notification Failure!", future.cause());
                     } else {
                         LOG.info("Sent NOT_FOUND to \"{}\" (Token: {}).", remoteSocket, token);
                     }
@@ -386,14 +388,13 @@ public class ServerObservationHandler extends AbstractCoapChannelHandler impleme
                 updateNotification.setObserve();
                 updateNotification.setPreferredBlock2Size(block2Size);
 
-                ChannelFuture future = Channels.future(getContext().getChannel());
-                sendCoapMessage(updateNotification, remoteSocket, future);
+                ChannelFuture future = sendCoapMessage(updateNotification, remoteSocket);
 
                 future.addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {
                         if (!future.isSuccess()) {
-                            LOG.error("Update Notification Failure!", future.getCause());
+                            LOG.error("Update Notification Failure!", future.cause());
                         } else {
                             LOG.info("Update Notification sent to \"{}\" (Token: {}).", remoteSocket, token);
                         }

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/reliability/outbound/ClientOutboundReliabilityHandler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/reliability/outbound/ClientOutboundReliabilityHandler.java
@@ -24,21 +24,34 @@
  */
 package de.uzl.itm.ncoap.communication.reliability.outbound;
 
-import com.google.common.collect.*;
-import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.events.*;
-import de.uzl.itm.ncoap.message.*;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.util.Observable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import de.uzl.itm.ncoap.communication.dispatching.Token;
+import de.uzl.itm.ncoap.communication.events.EmptyAckReceivedEvent;
+import de.uzl.itm.ncoap.communication.events.MessageIDAssignedEvent;
+import de.uzl.itm.ncoap.communication.events.MessageIDReleasedEvent;
+import de.uzl.itm.ncoap.communication.events.MessageRetransmittedEvent;
+import de.uzl.itm.ncoap.communication.events.MiscellaneousErrorEvent;
+import de.uzl.itm.ncoap.communication.events.NoMessageIDAvailableEvent;
+import de.uzl.itm.ncoap.communication.events.ResetReceivedEvent;
+import de.uzl.itm.ncoap.communication.events.TransmissionTimeoutEvent;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.CoapResponse;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 
 
 /**
@@ -259,7 +272,7 @@ public class ClientOutboundReliabilityHandler extends AbstractOutboundReliabilit
                         triggerEvent(new MessageRetransmittedEvent(remoteSocket, messageID, token), false);
                         LOG.debug("Finished transmission #{}: {}", transmissionNumber, coapMessage);
                     } else {
-                        String desc = "Transmission failed (\"" + future.getCause().getMessage() + "\"";
+                        String desc = "Transmission failed (\"" + future.cause().getMessage() + "\"";
                         triggerEvent(new MiscellaneousErrorEvent(remoteSocket, messageID, token, desc), false);
                     }
                 }

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/reliability/outbound/ServerOutboundReliabilityHandler.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/reliability/outbound/ServerOutboundReliabilityHandler.java
@@ -24,26 +24,27 @@
  */
 package de.uzl.itm.ncoap.communication.reliability.outbound;
 
-import com.google.common.collect.HashBasedTable;
-import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.events.ResetReceivedEvent;
-import de.uzl.itm.ncoap.communication.events.TransmissionTimeoutEvent;
-import de.uzl.itm.ncoap.message.CoapMessage;
-import de.uzl.itm.ncoap.message.CoapResponse;
-import de.uzl.itm.ncoap.message.MessageCode;
-import de.uzl.itm.ncoap.message.MessageType;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.Channels;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashBasedTable;
+import de.uzl.itm.ncoap.communication.dispatching.Token;
+import de.uzl.itm.ncoap.communication.events.ResetReceivedEvent;
+import de.uzl.itm.ncoap.communication.events.TransmissionTimeoutEvent;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapMessageEnvelope;
+import de.uzl.itm.ncoap.message.CoapResponse;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 
 
 /**
@@ -293,8 +294,7 @@ public class ServerOutboundReliabilityHandler extends AbstractOutboundReliabilit
                 }
 
                 // retransmit message
-                ChannelFuture future = Channels.future(getContext().getChannel());
-                Channels.write(getContext(), future, coapResponse, remoteSocket);
+                ChannelFuture future = getContext().writeAndFlush(new CoapMessageEnvelope(coapResponse, remoteSocket));
                 future.addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {

--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/message/CoapMessageEnvelope.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/message/CoapMessageEnvelope.java
@@ -22,22 +22,22 @@
  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package de.uzl.itm.ncoap.communication.codec.tools;
+package de.uzl.itm.ncoap.message;
 
-import de.uzl.itm.ncoap.communication.codec.CoapMessageDecoder;
-import io.netty.buffer.ByteBuf;
+import java.net.InetSocketAddress;
+
+import io.netty.channel.DefaultAddressedEnvelope;
 
 /**
-* Created with IntelliJ IDEA.
-* User: olli
-* Date: 12.11.13
-* Time: 23:54
-* To change this template use File | Settings | File Templates.
-*/
-public class CoapTestDecoder extends CoapMessageDecoder{
-
-    public Object decode(ByteBuf buffer) throws Exception {
-        return super.decode(null, buffer);
+ * Purpose of this class is to carry around addressing information for a coap request (without
+ * corrupting the CoapMessage model with fields that aren't actually part of the message).
+ */
+public class CoapMessageEnvelope extends DefaultAddressedEnvelope<CoapMessage, InetSocketAddress> {
+    public CoapMessageEnvelope(CoapMessage message, InetSocketAddress recipient, InetSocketAddress sender) {
+        super(message, recipient, sender);
     }
 
+    public CoapMessageEnvelope(CoapMessage message, InetSocketAddress recipient) {
+        super(message, recipient);
+    }
 }

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/ServerSendsPiggyBackedResponseTest.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/ServerSendsPiggyBackedResponseTest.java
@@ -24,24 +24,27 @@
  */
 package de.uzl.itm.ncoap.communication;
 
-import de.uzl.itm.ncoap.application.client.CoapClient;
-import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.reliability.inbound.ClientInboundReliabilityHandler;
-import de.uzl.itm.ncoap.endpoints.DummyEndpoint;
-import de.uzl.itm.ncoap.endpoints.client.TestCallback;
-import de.uzl.itm.ncoap.message.*;
-import de.uzl.itm.ncoap.message.options.ContentFormat;
-
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.SortedMap;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import java.net.URI;
-import java.util.SortedMap;
+import de.uzl.itm.ncoap.application.client.CoapClient;
+import de.uzl.itm.ncoap.communication.dispatching.Token;
+import de.uzl.itm.ncoap.communication.reliability.inbound.ClientInboundReliabilityHandler;
+import de.uzl.itm.ncoap.endpoints.DummyEndpoint;
+import de.uzl.itm.ncoap.endpoints.client.TestCallback;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.CoapResponse;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
+import de.uzl.itm.ncoap.message.options.ContentFormat;
 
-import static junit.framework.Assert.*;
+import static junit.framework.Assert.assertEquals;
 
 
 /**
@@ -114,20 +117,25 @@ public class ServerSendsPiggyBackedResponseTest extends AbstractCoapCommunicatio
         Token token = endpoint.getReceivedCoapMessages().values().iterator().next().getToken();
 
         //write response #1
-        CoapResponse response = new CoapResponse(MessageType.ACK, MessageCode.CONTENT_205);
-        response.setMessageID(messageID);
-        response.setToken(token);
-        response.setContent(PAYLOAD.getBytes(CoapMessage.CHARSET), ContentFormat.TEXT_PLAIN_UTF8);
-        endpoint.writeMessage(response, new InetSocketAddress("localhost", client.getPort()));
+        endpoint.writeMessage(response(messageID, token), new InetSocketAddress("localhost", client.getPort()));
 
         //Wait some time
         Thread.sleep(1000);
 
         //write response #2 (should be ignored by the client!)
-        endpoint.writeMessage(response, new InetSocketAddress("localhost", client.getPort()));
+        endpoint.writeMessage(response(messageID, token), new InetSocketAddress("localhost", client.getPort()));
 
         //Wait some time
         Thread.sleep(500);
+    }
+
+    private CoapResponse response(int messageID, Token token)
+    {
+        CoapResponse response = new CoapResponse(MessageType.ACK, MessageCode.CONTENT_205);
+        response.setMessageID(messageID);
+        response.setToken(token);
+        response.setContent(PAYLOAD.getBytes(CoapMessage.CHARSET), ContentFormat.TEXT_PLAIN_UTF8);
+        return response;
     }
 
 

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/blockwise/ClientSendsMultiplePostRequestsWithBlock1AndBlock2.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/blockwise/ClientSendsMultiplePostRequestsWithBlock1AndBlock2.java
@@ -24,21 +24,26 @@
  */
 package de.uzl.itm.ncoap.communication.blockwise;
 
+import java.net.InetSocketAddress;
+import java.net.URI;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
 import de.uzl.itm.ncoap.application.client.CoapClient;
 import de.uzl.itm.ncoap.application.server.CoapServer;
 import de.uzl.itm.ncoap.communication.AbstractCoapCommunicationTest;
 import de.uzl.itm.ncoap.endpoints.client.TestCallback;
 import de.uzl.itm.ncoap.endpoints.server.NotObservableTestWebresourceForPost;
-import de.uzl.itm.ncoap.message.*;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.CoapResponse;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
 import de.uzl.itm.ncoap.message.options.ContentFormat;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.junit.Test;
-
-import java.net.InetSocketAddress;
-import java.net.URI;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import static org.junit.Assert.assertEquals;
 
@@ -86,7 +91,7 @@ public class ClientSendsMultiplePostRequestsWithBlock1AndBlock2 extends Abstract
             coapRequests[i].setPreferredBlock2Size(initialRequestBlock2Size);
 
             // payload length = 5 x 26 = 130
-            ChannelBuffer payload = ChannelBuffers.wrappedBuffer(capitals, capitals, capitals, capitals, capitals);
+            ByteBuf payload = Unpooled.wrappedBuffer(capitals, capitals, capitals, capitals, capitals);
             coapRequests[i].setContent(payload, ContentFormat.TEXT_PLAIN_UTF8);
 
             // setup callback

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/AllowDefaultOptionValues.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/AllowDefaultOptionValues.java
@@ -1,3 +1,27 @@
+/**
+ * Copyright (c) 2016, Oliver Kleine, Institute of Telematics, University of Luebeck
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ *  - Redistributions of source messageCode must retain the above copyright notice, this list of conditions and the following
+ *    disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *    following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the University of Luebeck nor the names of its contributors may be used to endorse or promote
+ *    products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package de.uzl.itm.ncoap.communication.codec;
 
 import de.uzl.itm.ncoap.AbstractCoapTest;

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/DecodeEncodedMessageTest.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/DecodeEncodedMessageTest.java
@@ -24,26 +24,27 @@
  */
 package de.uzl.itm.ncoap.communication.codec;
 
-import com.google.common.collect.Lists;
-import de.uzl.itm.ncoap.AbstractCoapTest;
-import de.uzl.itm.ncoap.communication.dispatching.Token;
-import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
-import de.uzl.itm.ncoap.communication.codec.tools.CoapTestEncoder;
-import de.uzl.itm.ncoap.message.MessageCode;
-import de.uzl.itm.ncoap.message.options.ContentFormat;
-import de.uzl.itm.ncoap.message.CoapMessage;
-import de.uzl.itm.ncoap.message.CoapRequest;
-import de.uzl.itm.ncoap.message.MessageType;
+import java.net.URI;
+import java.util.Collection;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.jboss.netty.buffer.ChannelBuffer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.net.URI;
-import java.util.Collection;
+import com.google.common.collect.Lists;
+import de.uzl.itm.ncoap.AbstractCoapTest;
+import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
+import de.uzl.itm.ncoap.communication.codec.tools.CoapTestEncoder;
+import de.uzl.itm.ncoap.communication.dispatching.Token;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
+import de.uzl.itm.ncoap.message.options.ContentFormat;
+import io.netty.buffer.ByteBuf;
 
 import static org.junit.Assert.assertEquals;
 
@@ -75,7 +76,7 @@ public class DecodeEncodedMessageTest extends AbstractCoapTest {
     }
 
     private CoapMessage coapMessage;
-    private ChannelBuffer encodedMessage;
+    private ByteBuf encodedMessage;
 
     public DecodeEncodedMessageTest(CoapMessage coapMessage) throws Exception {
         coapMessage.setMessageID(1234);

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/MessageDecodingWithInvalidMessages.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/MessageDecodingWithInvalidMessages.java
@@ -24,20 +24,21 @@
  */
 package de.uzl.itm.ncoap.communication.codec;
 
-import com.google.common.collect.Lists;
-import de.uzl.itm.ncoap.AbstractCoapTest;
-import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
+import java.util.Collection;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
+import com.google.common.collect.Lists;
+import de.uzl.itm.ncoap.AbstractCoapTest;
+import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 
 
@@ -74,12 +75,12 @@ public class MessageDecodingWithInvalidMessages extends AbstractCoapTest{
         Logger.getRootLogger().setLevel(Level.ERROR);
     }
 
-    private ChannelBuffer encodedMessageBuffer;
+    private ByteBuf encodedMessageBuffer;
 
 
     public MessageDecodingWithInvalidMessages(byte[] encodedMessage, Class<Exception> expectedExceptionClass,
                                               String expectedMessage) {
-        this.encodedMessageBuffer = ChannelBuffers.wrappedBuffer(encodedMessage);
+        this.encodedMessageBuffer = Unpooled.wrappedBuffer(encodedMessage);
         exception.expect(expectedExceptionClass);
         exception.expectMessage(expectedMessage);
     }

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/MessageDecodingWithValidMessages.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/MessageDecodingWithValidMessages.java
@@ -24,20 +24,21 @@
  */
 package de.uzl.itm.ncoap.communication.codec;
 
-import com.google.common.collect.Lists;
-import de.uzl.itm.ncoap.AbstractCoapTest;
-import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
-import de.uzl.itm.ncoap.message.CoapMessage;
+import java.util.Collection;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
+import com.google.common.collect.Lists;
+import de.uzl.itm.ncoap.AbstractCoapTest;
+import de.uzl.itm.ncoap.communication.codec.tools.CoapTestDecoder;
+import de.uzl.itm.ncoap.message.CoapMessage;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import static org.junit.Assert.assertEquals;
 
@@ -74,14 +75,14 @@ public class MessageDecodingWithValidMessages extends AbstractCoapTest {
     }
 
 
-    private ChannelBuffer encodedMessageBuffer;
+    private ByteBuf encodedMessageBuffer;
     private CoapMessage expected;
     private CoapMessage actual;
 
 
     public MessageDecodingWithValidMessages(byte[] encodedMessage, CoapMessage expected) {
         this.expected = expected;
-        this.encodedMessageBuffer = ChannelBuffers.wrappedBuffer(encodedMessage);
+        this.encodedMessageBuffer = Unpooled.wrappedBuffer(encodedMessage);
     }
 
 

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/OptionEncoding.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/OptionEncoding.java
@@ -24,23 +24,24 @@
  */
 package de.uzl.itm.ncoap.communication.codec;
 
-import com.google.common.collect.Lists;
-import de.uzl.itm.ncoap.AbstractCoapTest;
-import de.uzl.itm.ncoap.communication.codec.tools.CoapTestEncoder;
-import de.uzl.itm.ncoap.message.options.Option;
-import de.uzl.itm.ncoap.message.options.OptionValue;
-import de.uzl.itm.ncoap.message.options.StringOptionValue;
+import java.util.Collection;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
+import com.google.common.collect.Lists;
+import de.uzl.itm.ncoap.AbstractCoapTest;
+import de.uzl.itm.ncoap.communication.codec.tools.CoapTestEncoder;
+import de.uzl.itm.ncoap.message.options.Option;
+import de.uzl.itm.ncoap.message.options.OptionValue;
+import de.uzl.itm.ncoap.message.options.StringOptionValue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import static org.junit.Assert.assertEquals;
 
@@ -93,7 +94,7 @@ public class OptionEncoding extends AbstractCoapTest {
     private int optionNumber;
     private OptionValue optionValue;
 
-    private ChannelBuffer encodedOption;
+    private ByteBuf encodedOption;
 
 
     private OptionEncoding(int previousOptionNumber, int optionNumber, OptionValue optionValue) {
@@ -112,7 +113,7 @@ public class OptionEncoding extends AbstractCoapTest {
     @Before
     public void encodeOption() throws Exception {
         log.info("Start Tests with Option " + optionValue);
-        encodedOption = ChannelBuffers.dynamicBuffer();
+        encodedOption = Unpooled.buffer();
         coapTestEncoder.encodeOption(encodedOption, optionNumber, optionValue, previousOptionNumber);
     }
 
@@ -120,7 +121,7 @@ public class OptionEncoding extends AbstractCoapTest {
     public void testDeltaPartOfFirstByte() {
         int expectedDelta = this.optionNumber - this.previousOptionNumber;
 
-        ChannelBuffer buffer = ChannelBuffers.copiedBuffer(encodedOption);
+        ByteBuf buffer = Unpooled.copiedBuffer(encodedOption);
 
         int firstByte = buffer.readByte() & 0xFF;
 
@@ -150,7 +151,7 @@ public class OptionEncoding extends AbstractCoapTest {
     public void testLengthPartOfFirstByte() {
         int expectedLength = this.optionValue.getValue().length;
 
-        ChannelBuffer buffer = ChannelBuffers.copiedBuffer(encodedOption);
+        ByteBuf buffer = Unpooled.copiedBuffer(encodedOption);
 
         int firstByte = buffer.readByte() & 0xFF;
 
@@ -184,7 +185,7 @@ public class OptionEncoding extends AbstractCoapTest {
 
         int expectedDelta = this.optionNumber - this.previousOptionNumber;
 
-        ChannelBuffer buffer = ChannelBuffers.copiedBuffer(encodedOption);
+        ByteBuf buffer = Unpooled.copiedBuffer(encodedOption);
         buffer.readByte();
 
         if (expectedDelta >= 13 && expectedDelta < 269) {
@@ -208,7 +209,7 @@ public class OptionEncoding extends AbstractCoapTest {
 
         int expectedLength = optionValue.getValue().length;
 
-        ChannelBuffer buffer = ChannelBuffers.copiedBuffer(encodedOption);
+        ByteBuf buffer = Unpooled.copiedBuffer(encodedOption);
         int firstByte = buffer.readByte();
         int deltaPart = (firstByte & 0xFF) >>> 4 ;
 

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/tools/CoapTestEncoder.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/tools/CoapTestEncoder.java
@@ -52,7 +52,7 @@ import de.uzl.itm.ncoap.communication.codec.CoapMessageEncoder;
 import de.uzl.itm.ncoap.communication.codec.OptionCodecException;
 import de.uzl.itm.ncoap.message.CoapMessage;
 import de.uzl.itm.ncoap.message.options.OptionValue;
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
 
 /**
 * Created with IntelliJ IDEA.
@@ -63,11 +63,11 @@ import org.jboss.netty.buffer.ChannelBuffer;
 */
 public class CoapTestEncoder extends CoapMessageEncoder{
 
-    public ChannelBuffer encode(CoapMessage coapMessage) throws OptionCodecException {
+    public ByteBuf encode(CoapMessage coapMessage) throws OptionCodecException {
         return super.encode(coapMessage);
     }
 
-    public void encodeOption(ChannelBuffer buffer, int optionNumber, OptionValue optionValue, int prevNumber)
+    public void encodeOption(ByteBuf buffer, int optionNumber, OptionValue optionValue, int prevNumber)
             throws OptionCodecException {
 
         super.encodeOption(buffer, optionNumber, optionValue, prevNumber);

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/endpoints/DummyEndpoint.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/endpoints/DummyEndpoint.java
@@ -115,6 +115,7 @@ public class DummyEndpoint extends ChannelDuplexHandler {
         if ((object instanceof CoapMessageEnvelope)) {
             CoapMessageEnvelope envelope = (CoapMessageEnvelope) object;
             CoapMessage message = envelope.content();
+            message.getContent().retain();
             InetSocketAddress remoteAddress = envelope.sender();
             receivedCoapMessages.put(System.currentTimeMillis(), message);
             log.info("Received #{} (from {}): {}.",

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/endpoints/client/TestCallback.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/endpoints/client/TestCallback.java
@@ -24,14 +24,19 @@
  */
 package de.uzl.itm.ncoap.endpoints.client;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Ordering;
 import de.uzl.itm.ncoap.application.client.ClientCallback;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.message.CoapResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 
 public class TestCallback extends ClientCallback {
@@ -64,6 +69,7 @@ public class TestCallback extends ClientCallback {
 
     @Override
     public void processCoapResponse(CoapResponse coapResponse) {
+       coapResponse.getContent().retain();
        coapResponses.put(System.currentTimeMillis(), coapResponse);
        log.info("Received #{}: {}", coapResponses.size(), coapResponse);
     }


### PR DESCRIPTION
Hello, first let me say thank you for the nCoAP library!

One of the projects I work on involves a CoAP proxy. The proxy uses netty 4. I have done some work already to port nCoAP to netty 4: https://github.com/earthling/nCoAP/tree/netty-4.0. All of the unit tests pass, but I am not quite sure it is ready for a pull request. I would like to start the conversation though. I'm also not sure how you would want to handle it, as it breaks compatibility with netty-3 users.

I'm also curious about this CoAP Endpoint Identification proposal you drafted: https://tools.ietf.org/html/draft-kleine-core-coap-endpoint-id-01​. CoAP proxies face a similar problem - specifically when it is necessary to keep track of authenticated clients (i.e., sessions). Are you aware of any other CoAP tools that support this proposal? do you think it likely to be accepted into the CoAP canon?

Thanks again,
William