### PR TITLE
Fixed build process with Maven

### DIFF
--- a/ncoap-simple-client/pom.xml
+++ b/ncoap-simple-client/pom.xml
@@ -44,7 +44,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.4</version>
                 <executions>

--- a/ncoap-simple-server/pom.xml
+++ b/ncoap-simple-server/pom.xml
@@ -39,7 +39,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.4</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,4 @@
         <!--</extensions>-->
     </build>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>onejar-maven-plugin.googlecode.com</id>
-            <url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>


### PR DESCRIPTION
Google Code is no more, and the Onejar Maven plugin has been forked/moved to the public Maven repo under a new groupId. This PR solves issue #33. 