### PR TITLE
Option decoding fix

### DIFF
--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageDecoder.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/codec/CoapMessageDecoder.java
@@ -216,13 +216,14 @@ public class CoapMessageDecoder extends SimpleChannelUpstreamHandler {
                 optionDelta += buffer.readByte() & 0xFF;
             } else if (optionDelta == 14) {
                 optionDelta = 269 + ((buffer.readByte() & 0xFF) << 8) + (buffer.readByte() & 0xFF);
-            } else {
-                if (optionLength == 13) {
-                    optionLength += buffer.readByte() & 0xFF;
-                } else if (optionLength == 14) {
-                    optionLength = 269 + ((buffer.readByte() & 0xFF) << 8) + (buffer.readByte() & 0xFF);
-                }
             }
+
+            if (optionLength == 13) {
+                optionLength += buffer.readByte() & 0xFF;
+            } else if (optionLength == 14) {
+                optionLength = 269 + ((buffer.readByte() & 0xFF) << 8) + (buffer.readByte() & 0xFF);
+            }
+
 
             log.info("Previous option: {}, Option delta: {}", previousOptionNumber, optionDelta);
 


### PR DESCRIPTION
Decoding option length should not depend on option number delta. This bug prevented the decoder from properly decoding the Proxy-URI option.