### PR TITLE
Allow URI-Host to contain IP literals

### DIFF
--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/message/options/OptionValue.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/message/options/OptionValue.java
@@ -24,16 +24,37 @@
  */
 package de.uzl.itm.ncoap.message.options;
 
-import com.google.common.net.InetAddresses;
-import com.google.common.primitives.Longs;
-import de.uzl.itm.ncoap.message.CoapMessage;
-
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static de.uzl.itm.ncoap.message.options.Option.*;
-import static de.uzl.itm.ncoap.message.options.OptionValue.Type.*;
+import com.google.common.primitives.Longs;
+
+import static de.uzl.itm.ncoap.message.options.Option.ACCEPT;
+import static de.uzl.itm.ncoap.message.options.Option.BLOCK_1;
+import static de.uzl.itm.ncoap.message.options.Option.BLOCK_2;
+import static de.uzl.itm.ncoap.message.options.Option.CONTENT_FORMAT;
+import static de.uzl.itm.ncoap.message.options.Option.ENDPOINT_ID_1;
+import static de.uzl.itm.ncoap.message.options.Option.ENDPOINT_ID_2;
+import static de.uzl.itm.ncoap.message.options.Option.ETAG;
+import static de.uzl.itm.ncoap.message.options.Option.IF_MATCH;
+import static de.uzl.itm.ncoap.message.options.Option.IF_NONE_MATCH;
+import static de.uzl.itm.ncoap.message.options.Option.LOCATION_PATH;
+import static de.uzl.itm.ncoap.message.options.Option.LOCATION_QUERY;
+import static de.uzl.itm.ncoap.message.options.Option.MAX_AGE;
+import static de.uzl.itm.ncoap.message.options.Option.OBSERVE;
+import static de.uzl.itm.ncoap.message.options.Option.PROXY_SCHEME;
+import static de.uzl.itm.ncoap.message.options.Option.PROXY_URI;
+import static de.uzl.itm.ncoap.message.options.Option.SIZE_1;
+import static de.uzl.itm.ncoap.message.options.Option.SIZE_2;
+import static de.uzl.itm.ncoap.message.options.Option.URI_HOST;
+import static de.uzl.itm.ncoap.message.options.Option.URI_PATH;
+import static de.uzl.itm.ncoap.message.options.Option.URI_PORT;
+import static de.uzl.itm.ncoap.message.options.Option.URI_QUERY;
+import static de.uzl.itm.ncoap.message.options.OptionValue.Type.EMPTY;
+import static de.uzl.itm.ncoap.message.options.OptionValue.Type.OPAQUE;
+import static de.uzl.itm.ncoap.message.options.OptionValue.Type.STRING;
+import static de.uzl.itm.ncoap.message.options.OptionValue.Type.UINT;
 
 /**
  * {@link OptionValue} is the abstract base class for CoAP options. It provides a number of useful static constants and
@@ -200,23 +221,8 @@ public abstract class OptionValue<T>{
      * @return <code>true</code> if the given value is the default value for the given option number
      */
     public static boolean isDefaultValue(int optionNumber, byte[] value) {
-
-        if (optionNumber == URI_PORT && Arrays.equals(value, ENCODED_URI_PORT_DEFAULT)) {
-            return true;
-        } else if (optionNumber == MAX_AGE && Arrays.equals(value, ENCODED_MAX_AGE_DEFAULT)) {
-            return true;
-        } else  if (optionNumber == URI_HOST) {
-            String hostName = new String(value, CoapMessage.CHARSET);
-            if (hostName.startsWith("[") && hostName.endsWith("]")) {
-                hostName = hostName.substring(1, hostName.length() - 1);
-            }
-
-            if (InetAddresses.isInetAddress(hostName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return optionNumber == Option.URI_PORT && Arrays.equals(value, ENCODED_URI_PORT_DEFAULT)
+            || optionNumber == Option.MAX_AGE && Arrays.equals(value, ENCODED_MAX_AGE_DEFAULT);
     }
 
 

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/message/CoapRequestUriOptionsTest.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/message/CoapRequestUriOptionsTest.java
@@ -24,7 +24,11 @@
  */
 package de.uzl.itm.ncoap.message;
 
-import de.uzl.itm.ncoap.AbstractCoapTest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.After;
@@ -33,10 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collection;
+import de.uzl.itm.ncoap.AbstractCoapTest;
 
 import static org.junit.Assert.assertEquals;
 
@@ -56,8 +57,9 @@ public class CoapRequestUriOptionsTest extends AbstractCoapTest{
         return Arrays.asList(new Object[][] {
             {
                 new URI("coap", null, "[2001:db8::2:1]", -1, null, null, null),
-                null, 5683, "/", ""
-            },{
+                "[2001:db8::2:1]", 5683, "/", ""
+            },
+            {
                 new URI("coap", null, "example.net", 5683, null, null, null),
                 "example.net", 5683, "/", ""
             },{
@@ -75,9 +77,10 @@ public class CoapRequestUriOptionsTest extends AbstractCoapTest{
             },{
                 new URI("coap", null, "example.com", 5683, "/%7esensors/temp.xml", null, null),
                 "example.com", 5683, "/~sensors/temp.xml", ""
-            },{
+            }
+            ,{
                 new URI("coap", null, "198.51.100.1", 61616, "//%2F//", "%2F%2F&?%26", null),
-                null, 61616,  "//", "//&?&"
+                "198.51.100.1", 61616,  "//", "//&?&"
             }
         });
     }


### PR DESCRIPTION
This is necessary to support IP literals with the Proxy-Scheme and Proxy-URI options.