### PR TITLE
Fixing SimpleCoapServer + SimpleCoapClient -- step I

### DIFF
--- a/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/BlockSize.java
+++ b/ncoap-core/src/main/java/de/uzl/itm/ncoap/communication/blockwise/BlockSize.java
@@ -24,9 +24,6 @@
  */
 package de.uzl.itm.ncoap.communication.blockwise;
 
-import de.uzl.itm.ncoap.message.options.UintOptionValue;
-import jdk.nashorn.internal.ir.Block;
-
 /**
  * Created by olli on 09.02.16.
  */

--- a/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/AllowDefaultOptionValues.java
+++ b/ncoap-core/src/test/java/de/uzl/itm/ncoap/communication/codec/AllowDefaultOptionValues.java
@@ -1,3 +1,27 @@
+/**
+ * Copyright (c) 2016, Oliver Kleine, Institute of Telematics, University of Luebeck
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ *  - Redistributions of source messageCode must retain the above copyright notice, this list of conditions and the following
+ *    disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *    following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  - Neither the name of the University of Luebeck nor the names of its contributors may be used to endorse or promote
+ *    products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package de.uzl.itm.ncoap.communication.codec;
 
 import de.uzl.itm.ncoap.AbstractCoapTest;

--- a/ncoap-simple-client/src/main/java/de/uzl/itm/ncoap/examples/client/SimpleCoapClient.java
+++ b/ncoap-simple-client/src/main/java/de/uzl/itm/ncoap/examples/client/SimpleCoapClient.java
@@ -24,17 +24,20 @@
  */
 package de.uzl.itm.ncoap.examples.client;
 
-import de.uzl.itm.ncoap.application.client.ClientCallback;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
 import de.uzl.itm.ncoap.application.client.CoapClient;
-import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.examples.client.callback.SimpleCallback;
 import de.uzl.itm.ncoap.examples.client.callback.SimpleObservationCallback;
 import de.uzl.itm.ncoap.examples.client.config.ClientCmdLineArgumentsWrapper;
 import de.uzl.itm.ncoap.examples.client.config.LoggingConfiguration;
-import de.uzl.itm.ncoap.message.*;
-import de.uzl.itm.ncoap.message.options.ContentFormat;
-
-import java.net.*;
+import de.uzl.itm.ncoap.message.CoapRequest;
+import de.uzl.itm.ncoap.message.MessageCode;
+import de.uzl.itm.ncoap.message.MessageType;
 
 
 /**
@@ -137,7 +140,6 @@ public class SimpleCoapClient extends CoapClient {
         this.shutdown();
     }
 
-
     private boolean isShutdownCriterionSatisfied(long startTime) {
 
         //Check if maximum duration was reached
@@ -176,14 +178,15 @@ public class SimpleCoapClient extends CoapClient {
         }
 
         // Start the client
-//        SimpleCoapClient client = new SimpleCoapClient(arguments);
-//
-//        // Send the request
-//        client.sendCoapRequest();
-//
-//        // wait for shutdown criterion and shutdown...
-//        client.waitAndShutdown();
+        SimpleCoapClient client = new SimpleCoapClient(arguments);
 
+        // Send the request
+        client.sendCoapRequest();
+
+        // wait for shutdown criterion and shutdown...
+        client.waitAndShutdown();
+
+        /*
         CoapClient client = new CoapClient("Simple CoAP Client", 6000);
 
         URI uri = new URI("coap", null, "vs0.inf.ethz.ch", 5683, "/obs-large", null, null);
@@ -209,6 +212,7 @@ public class SimpleCoapClient extends CoapClient {
 //                        }
 //                    }
 //                }
+
             }
 
             @Override
@@ -229,8 +233,7 @@ public class SimpleCoapClient extends CoapClient {
 
         Thread.sleep(90000);
         client.shutdown();
-
-
+*/
 
     }
 }

--- a/ncoap-simple-server/src/main/java/de/uzl/itm/ncoap/examples/server/SimpleCoapServer.java
+++ b/ncoap-simple-server/src/main/java/de/uzl/itm/ncoap/examples/server/SimpleCoapServer.java
@@ -29,8 +29,6 @@ import de.uzl.itm.ncoap.application.server.CoapServer;
 import de.uzl.itm.ncoap.communication.blockwise.BlockSize;
 import de.uzl.itm.ncoap.message.options.OptionValue;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 /**
  * This is a simple application to showcase how to use nCoAP for servers
  *

--- a/ncoap-simple-server/src/main/resources/log4j.default.xml
+++ b/ncoap-simple-server/src/main/resources/log4j.default.xml
@@ -29,8 +29,12 @@
         <!--<level value="info"/>-->
     <!--</logger>-->
 
+    <logger name="de.uzl.itm.ncoap.examples.server">
+    	<level value="info"/>
+    </logger>
+
     <logger name="de.uzl.itm.ncoap.application.server.resource.WellKnownCoreResource">
-    <level value="debug"/>
+    	<level value="debug"/>
     </logger>
 
     <root>


### PR DESCRIPTION
The current _simple-client_ cannot be used to communitcate to the _simple-server_, since some block-wise transfer which communicated to vs0.inf.ethz.ch is included in the example.

Thus, I tried to get the _simple-server_ and _simple-client_ running again. I created some small fixes (see this PR). I am building the project (with my fixes) as follows:

```
mvn package -DskipTests
```

Then I am running the two example applications in two terminals:

```
java -jar ncoap-simple-server/target/ncoap-simple-server-1.8.3-SNAPSHOT.one-jar.jar 
java -jar ncoap-simple-client/target/ncoap-simple-client-1.8.3-SNAPSHOT.one-jar.jar --host localhost --port 5683 --path /utc-time --observing --maxUpdates 100
```

The client gets one log `Payload: The current time is 11:30:27`, followed by `Blockwise response transfer failed!` for each notification.

What do I have to change in the (fixed) client/server to get the examples work again?